### PR TITLE
fix bug: ignore edns data

### DIFF
--- a/fakedns.py
+++ b/fakedns.py
@@ -32,8 +32,6 @@ class DNSQuery:
     self.data=data
     self.dominio=''
     tipo = (ord(data[2]) >> 3) & 15   # Opcode bits
-    self.type = data[-4:-2]           # Hackish -- this is where the type bits live -- 2 away from the last 4 bytes of the request.
-
     if tipo == 0:                     # Standard query
       ini=12
       lon=ord(data[ini])
@@ -41,6 +39,9 @@ class DNSQuery:
         self.dominio+=data[ini+1:ini+lon+1]+'.'
         ini+=lon+1 #you can implement CNAME and PTR
         lon=ord(data[ini])
+      self.type = datt[ini:][1:3]
+    else:
+      self.type = data[-4:-2]
 
 # Because python doesn't have native ENUM in 2.7:
 TYPE = {


### PR DESCRIPTION
Client:

    ➜ ~ dig @114.114.114.114 a.qwwq.pw

    ; <<>> DiG 9.8.3-P1 <<>> @114.114.114.114 a.qwwq.pw
    ; (1 server found)
    ;; global options: +cmd
    ;; Got answer:
    ;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 55117
    ;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0

    ;; QUESTION SECTION:
    ;a.qwwq.pw.         IN  A

    ;; Query time: 672 msec
    ;; SERVER: 114.114.114.114#53(114.114.114.114)
    ;; WHEN: Tue Apr 21 21:22:01 2015
    ;; MSG SIZE  rcvd: 27  

Server:

    ➜ FakeDns git:(master) ✗ sudo python fakedns.py -c dns.conf
    >> Parse rules...
    >> .*qwwq\.pw -> 103.238.227.183
    >> .*sellmoe.com -> 103.238.227.183
    >> 2 rules parsed
    4173000000010000000000010161047177777102707700000100010000291000000080000000
    0001 8000
    >> Matched Request - a.qwwq.pw.

The DNS query flag is 0001 rather than 8000.