### PR TITLE
Fixed error on blank lines with spaces

### DIFF
--- a/fakedns.py
+++ b/fakedns.py
@@ -371,7 +371,7 @@ class RuleEngine2:
             for rule in rules:
 
                 # ignore blank lines or lines starting with hashmark (coments)
-                if rule == "" or rule.lstrip()[0] == "#" or rule == '\n':
+                if len(rule.strip()) == 0 or rule.lstrip()[0] == "#" or rule == '\n':
                     # thank you to github user cambid for the comments suggestion
                     continue
 


### PR DESCRIPTION
Having an empty line with spaces on the configuration file will throw an error.

```
Traceback (most recent call last):
  File ".\fakedns.py", line 533, in <module>
    rules = RuleEngine2(path)
  File ".\fakedns.py", line 374, in __init__
    if rule == "" or rule.lstrip()[0] == "#" or rule == '\n':
IndexError: string index out of range
```