### PR TITLE
fakedns.py asnwered wrong IP v4 address

### DIFF
--- a/fakedns.py
+++ b/fakedns.py
@@ -217,13 +217,13 @@ class A(DNSResponse):
         super(A, self).__init__(query)
         self.type = b"\x00\x01"
         self.length = b"\x00\x04"
-        self.data = self.get_ip(record).encode()
+        self.data = self.get_ip(record)
 
     @staticmethod
     def get_ip(dns_record):
         ip = dns_record
         # Convert to hex
-        return ''.join(chr(int(x)) for x in ip.split('.'))
+        return b''.join(int(x).to_bytes(1, 'little') for x in ip.split('.'))
 
 # Implemented
 class AAAA(DNSResponse):


### PR DESCRIPTION
[Problem]
fakedns.py responds wrong IP v4  address:

[Environment]
MacOSX 10.15
Python 3.7.3

[Test case]
1. add following entry dns.conf:
A www\.example\.com 192.168.2.5
2. use builtin nslookup command

[Server responds]
---
Non-authoritative answer:
Name:   www.example.com
Address: 93.184.216.34
---

[How to fix]
directly composing byte array in the usage of Integer.to_byte() instead of chr()
Quit encoding at line 220
