### PR TITLE
Test Case and Docker-Compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-dns.conf
-venv
+venv/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dns.conf
+venv

--- a/README.md
+++ b/README.md
@@ -78,16 +78,6 @@ I have had a lot of success testing/developing FakeDNS in Docker because it's ea
 
 If you want to try it out, you can do so without much heavy lifting by following these steps:
 
-Assuming you are **_inside the FakeDns directory_**:
+Assuming you are **_inside the FakeDns directory_**: `sudo docker run --interactive --tty --volume \`pwd\`:/opt/FakeDns -p 5353:53/udp python:3.8 /opt/FakeDns/fakedns.py -c /opt/FakeDns/dns.conf.example`. And to test you can run `nslookup -port=5353 testrule.test 127.0.0.1` which should return `1.1.1.1` on your first request
 
-    sudo docker pull ubuntu
-    sudo docker run -it -v `pwd`:/opt -P --privileged --expose 53 ubuntu:latest /bin/bash
-    
-You'll then be at a docker root bash prompt which you can use to install python2.7 and run FakeDns:
-
-    apt-get update && apt-get install -y python
-    cd /opt
-    python fakedns.py -c dns.conf.example
-
-If you're new to docker and you don't have any other docker containers running, you'll probably have an IP of 172.17.0.2 for your now-running container, which you can hit using nslookup.
-From there you'll be able to figure it out.  If there's enough interest I will make a script for this or a docker image which will be pushed to the docker community hub.
+Or, if you'd like to use docker-compose, simply run `docker-compose up` and use the same test as above.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,10 @@ services:
     volumes:
       - ./:/opt/FakeDns
     ports: 
-      - "5353:53/udp"
+      - "53:53/udp"
+  FakeDns-test:
+    container_name: FakeDns-test
+    image: fakedns-test:latest
+    build: ./tests
+    depends_on: 
+      - FakeDns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   FakeDns:
     container_name: FakeDns
     image: python:3.8
+    working_dir: /opt/FakeDns/
     command: /opt/FakeDns/fakedns.py -c /opt/FakeDns/dns.conf.example
     volumes:
       - ./:/opt/FakeDns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+services:
+  FakeDns:
+    container_name: FakeDns
+    image: python:3.8
+    command: /opt/FakeDns/fakedns.py -c /opt/FakeDns/dns.conf.example
+    volumes:
+      - ./:/opt/FakeDns
+    ports: 
+      - "5353:53/udp"

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.8
+
+WORKDIR /opt/FakeDns/tests
+COPY ./ /opt/FakeDns/tests
+RUN pip install dnspython
+CMD python3 -m unittest discover -v /opt/FakeDns/tests

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,125 @@
+#!/bin/env python3
+# -*- coding: utf-8 -*-
+"""Test framework for FakeDns"""
+
+
+"""Imported Libraries
+
+unittest - Unit Testing Python Framework
+socket - Do one cheap DNS Lookup variant 
+dns - DNS Query library
+"""
+import unittest
+import socket
+import dns.resolver
+
+
+"""Global Variables
+
+"""
+
+
+class DNSTestCase(unittest.TestCase):
+    """Parent Class to give common function and setUp
+    """
+
+
+    def _dns_lookup(self, q: str, record_type: str) -> str:
+        """Does a DNS lookup for us, and returns the string
+
+        :param q: query (ip or hostname)
+        :type q: str
+        :param record_type: DNS record type
+        :type record_type: str
+        :return: DNS response
+        :rtype: str
+        """
+        # Ask the DNS server
+        answer = self.resolver.resolve(q, record_type)
+        # Make sure we only got one response
+        if len(answer.rrset) != 1:
+            raise RuntimeError(
+                "ERROR: More than one record set return in _dns_lookup(\"{}\", \"{}\")".format(q, record_type)
+            )
+        # Return the value
+        return answer.rrset[0].to_text()
+
+
+    def setUp(self):
+        """Creates the FakeDns Process
+        """ 
+        # Determine FakeDns IP address to use that as the name server
+        self.resolver = dns.resolver.Resolver()
+        self.resolver.nameservers = [socket.gethostbyname('FakeDns')] # Can't lookup 'FakeDns' via dns.resolver
+
+
+class TestRecordTypes(DNSTestCase):
+    """Checks the return of specific DNS Requests to ensure all record types are working as intended
+    """
+
+
+    def tearDown(self):
+        """Destroys the FakeDns process
+        """
+        del self.resolver    
+
+
+    def test_ARecord(self):
+        """Tests A Record
+        """
+        dns_response = self._dns_lookup("test.reddit.com", "A")
+        self.assertEqual(dns_response, "8.8.8.8")
+
+
+    def test_TXTRecord(self):
+        """Tests TXT Record
+        """
+        dns_response = self._dns_lookup("anyvalue", "TXT")
+        self.assertEqual(dns_response, "\"HELLO\"")
+
+
+    def test_AAAARecord(self):
+        """Tests AAAA Record
+        """
+        dns_response = self._dns_lookup("lulz.com", "AAAA")
+        self.assertEqual(dns_response, "2607:f8b0:4006:807::100e")
+
+
+    def test_PTRRecord(self):
+        """Tests PTR Record
+        """
+        dns_response = self._dns_lookup("1.0.0.127", "PTR")
+        self.assertEqual(dns_response, "localhost.")
+
+
+    def test_SOARecord(self):
+        """Tests SOA Record
+        """
+        dns_response = self._dns_lookup("example.com", "SOA")
+        self.assertEqual(dns_response, "ns.icann.org. noc.dns.icann.org. 2020121101 7200 3600 1209600 3600")
+
+
+class TestFeatures(DNSTestCase):
+    """Tests various DNS features implemented in FakeDns
+    """
+
+
+    def test_Rebinding(self):
+        """Test DNS rebinding
+        """
+        # We do two rounds because we want to make sure the "wrapping around" feature doesn't break
+        answers = [self._dns_lookup("testrule.test", "A") for _ in range(6)]
+        expected_answers = ["1.1.1.1", "2.2.2.2", "3.3.3.3", "1.1.1.1", "2.2.2.2", "3.3.3.3"]
+        self.assertEqual(answers, expected_answers)
+
+
+    def test_RoundRobin(self):
+        """Test DNS roundrobin
+        """
+        answers = [self._dns_lookup("roundrobin", "A") for _ in range(13)]
+        expected_answers = ["1.1.1.1"] * 10 + ["2.2.2.2", "3.3.3.3", "4.4.4.4"]
+        self.assertEqual(answers, expected_answers)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -96,7 +96,9 @@ class TestRecordTypes(DNSTestCase):
         """Tests SOA Record
         """
         dns_response = self._dns_lookup("example.com", "SOA")
-        self.assertEqual(dns_response, "ns.icann.org. noc.dns.icann.org. 2020121101 7200 3600 1209600 3600")
+        self.assertTrue(
+            dns_response.startswith("ns1.example.com. mx.example.com. ") and dns_response.endswith(" 60 60 60 60")
+        )
 
 
 class TestFeatures(DNSTestCase):


### PR DESCRIPTION
Added test cases to ensure future functionality does not break any DNS features provided by the project. Also added a docker-compose.yml, so that running `sudo docker-compose up` will execute the test cases, and provide you with the running docker image.